### PR TITLE
Default value of Content-Type header

### DIFF
--- a/book/part2.rst
+++ b/book/part2.rst
@@ -193,7 +193,7 @@ charge of sending the response whenever you see fit.
 .. note::
 
     We haven't explicitly set the ``Content-Type`` header in the rewritten
-    code as the Response object defaults to ``UTF-8`` by default.
+    code as the Response object defaults to ``text/html`` by default.
 
 With the ``Request`` class, you have all the request information at your
 fingertips thanks to a nice and simple API::


### PR DESCRIPTION
A note on the the Response Class says: "We haven't explicitly set the Content-Type header in the rewritten code as the Response object defaults to UTF-8 by default.".

I believe instead of "UTF-8" this should be "text/html", right?
