### PR TITLE
Part12 fixes for clarity

### DIFF
--- a/book/part12.rst
+++ b/book/part12.rst
@@ -181,6 +181,20 @@ The front controller is now only about wiring everything together::
 
     $response->send();
 
+As all the objects are now created in the dependency injection container, the framework code should be the previous simple version::
+
+    <?php
+
+    // example.com/src/Simplex/Framework.php
+
+    namespace Simplex;
+
+    use Symfony\Component\HttpKernel\HttpKernel;
+
+    class Framework extends HttpKernel
+    {
+    }
+
 .. note::
 
     If you want a light alternative for your container, consider `Pimple`_, a


### PR DESCRIPTION
Fixed two things :
- the first example didn't work, the duplicate name '`HttpKernel`' makes the import impossible. I understand that this example is not supposed to be followed but it's here and most people will make the modifications to `src/Simplex/Framework.php` and `web/front.php`. For the sake of don-t-panic-the-newbie, all the code presented should work ::)
- Linked to the first point, expose the final code of `src/Simplex/Framework.php` to make sure everybody gets it.
