### PR TITLE
Update part06.rst

### DIFF
--- a/book/part06.rst
+++ b/book/part06.rst
@@ -164,7 +164,7 @@ Let's conclude with the new version of our framework::
     use Symfony\Component\Routing;
     use Symfony\Component\HttpKernel;
 
-    function render_template($request)
+    function render_template(Request $request)
     {
         extract($request->attributes->all());
         ob_start();


### PR DESCRIPTION
If $request is not typed there is an error : Controller "render_template" requires that you provide a value for the "$request" argument (because there is no default value or because there is a non optional argument after this one).
