### PR TITLE
Fixed issue with running phpunit in chapter #8

### DIFF
--- a/book/part08.rst
+++ b/book/part08.rst
@@ -154,6 +154,15 @@ Response::
 
     public function testControllerResponse()
     {
+        $request_context = new RequestContext();
+        $request_context->fromRequest(new Request());
+
+        $matcher
+          ->expects($this->once())
+          ->method('getContext')
+          ->will($this->returnValue($request_context))
+        ;
+
         $matcher = $this->getMock('Symfony\Component\Routing\Matcher\UrlMatcherInterface');
         $matcher
             ->expects($this->once())


### PR DESCRIPTION
Running phpunit without this changes leading to `Fatal error: Call to a member function fromRequest() on a non-object in /home/rosko/websites/framework.dev/src/Simplex/Framework.php on line 30` - which is `$this->matcher->getContext()->fromRequest($request);` because request context is not set.
